### PR TITLE
fix : geometry merging issue

### DIFF
--- a/__test__/ColorableMergedView.spec.ts
+++ b/__test__/ColorableMergedView.spec.ts
@@ -81,4 +81,11 @@ describe("ColorableMergedView", () => {
     expect(view.body).toBeUndefined();
     expect(view.edge).toBeUndefined();
   });
+
+  test("should not have parent elements when no geometries are added", async () => {
+    const view = generateView();
+    await view.merge();
+    expect(view.body?.geometryMerger.object3D.parent).toBeFalsy();
+    expect(view.edge?.geometryMerger.object3D.parent).toBeFalsy();
+  });
 });

--- a/src/merger/GeometryMerger.ts
+++ b/src/merger/GeometryMerger.ts
@@ -52,7 +52,10 @@ export class GeometryMerger<
   }
 
   async merge(): Promise<void> {
-    if (this.geometries.length === 0) return;
+    if (this.geometries.length === 0) {
+      this.object3D.parent?.remove(this.object3D);
+      return;
+    }
 
     this.object3D.geometry = BufferGeometryUtils.mergeGeometries(
       this.geometries,


### PR DESCRIPTION
This pull request fixes an issue with the geometry merging functionality. Previously, when no geometries were added, the parent elements were not properly removed. This PR adds a check to remove the parent elements when there are no geometries.