### PR TITLE
fix : Refactor build process and remove tsconfig.lib.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,14 +50,14 @@
     "prepare": "husky install",
     "preversion": "git checkout main && git pull && npm ci && npx vitest --run && npm run build",
     "postversion": "git add package.json package-lock.json && git checkout -b version/$(git describe --tags --abbrev=0)",
-    "buildTS": "tsc --project tsconfig.lib.json",
+    "buildTS": "tsc",
     "start:dev": "npm run server & npm run watch:tsc & npm run watch:workerBundle & npm run watch:demo",
     "build": "npm run buildTS & npm run typedocs & npm run demo",
     "demo": "npx @masatomakino/gulptask-demo-page --compileTarget ES2021 --compileModule es2020",
     "typedocs": "npx typedoc --out ./docs/api src/index.ts",
     "server": "browser-sync ./docs/demo -w",
     "watch:demo": "npm run demo -- -W",
-    "watch:tsc": "tsc --project tsconfig.lib.json -W --incremental"
+    "watch:tsc": "tsc -W --incremental"
   },
   "lint-staged": {
     "*.{js,ts,css,md}": "prettier --write"

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,5 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "**/*.spec.ts", "src/EdgeWorker.ts"]
-}


### PR DESCRIPTION
This pull request refactors the build process by removing the tsconfig.lib.json file and updating the buildTS script in package.json to use "tsc" instead. This simplifies the build process and ensures consistency.