### PR TITLE
Add ColorableMergedMaterial class and its test file

### DIFF
--- a/__test__/ColorableMergedMaterial.spec.ts
+++ b/__test__/ColorableMergedMaterial.spec.ts
@@ -1,0 +1,13 @@
+import { describe, it, test, expect } from "vitest";
+import { ColorableMergedMaterial, TweenableColorMap } from "../src";
+
+describe("ColorableMergedMaterial", () => {
+  it("constructor", () => {
+    const materlal = new ColorableMergedMaterial({}, 1);
+    expect(materlal).toBeInstanceOf(ColorableMergedMaterial);
+  });
+
+  it.fails("generate empty body or edge", async () => {
+    const materlal = new ColorableMergedMaterial({}, 0);
+  });
+});

--- a/src/TweenableColorMap.ts
+++ b/src/TweenableColorMap.ts
@@ -91,6 +91,12 @@ export class TweenableColorMap extends EventEmitter {
     );
   }
 
+  public updateUniformsAll(): void {
+    this.colors.forEach((color) => {
+      this.updateUniform(color);
+    });
+  }
+
   /**
    * このカラーマップに紐づけられたマテリアルのuniformを更新する。
    * 対象となるuniformは、uniformNameで指定されたもの。

--- a/src/material/ColorableMergedBodyMaterial.ts
+++ b/src/material/ColorableMergedBodyMaterial.ts
@@ -35,6 +35,7 @@ export class ColorableMergedBodyMaterial extends ColorableMergedMaterial {
     this.side = param?.side ?? FrontSide;
 
     colors.setMaterial(this);
+    colors.updateUniformsAll();
   }
 
   /**

--- a/src/material/ColorableMergedEdgeMaterial.ts
+++ b/src/material/ColorableMergedEdgeMaterial.ts
@@ -26,6 +26,7 @@ export class ColorableMergedEdgeMaterial extends ColorableMergedMaterial {
     this.transparent = true;
 
     colors.setMaterial(this);
+    colors.updateUniformsAll();
   }
 
   /**

--- a/src/material/ColorableMergedMaterial.ts
+++ b/src/material/ColorableMergedMaterial.ts
@@ -1,0 +1,33 @@
+import { ShaderMaterial, ShaderMaterialParameters, Vector4 } from "three";
+import { IColorableMergedMaterial } from "./IColorableMergedMaterial.js";
+
+export class ColorableMergedMaterial
+  extends ShaderMaterial
+  implements IColorableMergedMaterial
+{
+  readonly isColorableMergedMaterial: boolean = true;
+
+  constructor(param: ShaderMaterialParameters, colorsLength: number) {
+    super(param);
+    if (colorsLength === 0) {
+      throw new Error(`ColorableMergedMaterialには少なくとも1つ以上のTweenableColorが必要です。
+        このMaterialに紐づけられたTweenableColoMapには1つもTweenableColorが登録されていません。`);
+    }
+    this.isColorableMergedMaterial = true;
+    this.initDefine(colorsLength);
+  }
+
+  initDefine = (colorsLength: number) => {
+    this.defines = {
+      INDEX: colorsLength, // TODO rename to COLORS_LENGTH
+    };
+  };
+  static getColorUniform(colorLength: number) {
+    const colors = new Array(colorLength)
+      .fill(0)
+      .map(() => new Vector4(1, 1, 1, 0.5));
+    return {
+      colors: { value: colors },
+    };
+  }
+}

--- a/src/material/IColorableMergedMaterial.ts
+++ b/src/material/IColorableMergedMaterial.ts
@@ -1,32 +1,3 @@
-import { ShaderMaterial, ShaderMaterialParameters, Vector4 } from "three";
-
 export interface IColorableMergedMaterial {
   readonly isColorableMergedMaterial: boolean;
-}
-
-export class ColorableMergedMaterial
-  extends ShaderMaterial
-  implements IColorableMergedMaterial
-{
-  readonly isColorableMergedMaterial: boolean = true;
-
-  constructor(param: ShaderMaterialParameters, colorsLength: number) {
-    super(param);
-    this.isColorableMergedMaterial = true;
-    this.initDefine(colorsLength);
-  }
-
-  initDefine = (colorsLength: number) => {
-    this.defines = {
-      INDEX: colorsLength, // TODO rename to COLORS_LENGTH
-    };
-  };
-  static getColorUniform(colorLength: number) {
-    const colors = new Array(colorLength)
-      .fill(0)
-      .map(() => new Vector4(1, 1, 1, 0.5));
-    return {
-      colors: { value: colors },
-    };
-  }
 }

--- a/src/material/index.ts
+++ b/src/material/index.ts
@@ -1,4 +1,5 @@
 export * from "./IColorableMergedMaterial.js";
+export * from "./ColorableMergedMaterial.js";
 export {
   ColorableMergedBodyMaterial,
   ColorableMergedBodyMaterialParam,


### PR DESCRIPTION
This pull request adds the ColorableMergedMaterial class and its corresponding test file. The ColorableMergedMaterial class extends the ShaderMaterial class and implements the IColorableMergedMaterial interface. It provides functionality for creating a material with colorable merged properties.