### PR TITLE
add : ColorableMergedNodeMaterial

### DIFF
--- a/demoSrc/GenarateModel.ts
+++ b/demoSrc/GenarateModel.ts
@@ -1,16 +1,18 @@
-import { BoxGeometry, ShaderMaterial } from "three";
+import { BoxGeometry } from "three";
 import {
-  ColorableMergedBody,
   ColorableMergedBodyMaterial,
-  ColorableMergedEdge,
+  ColorableMergedBodyNodeMaterial,
   ColorableMergedEdgeMaterial,
+  ColorableMergedEdgeNodeMaterial,
   ColorableMergedView,
   TweenableColorMap,
 } from "../src/index.js";
 
 export async function generateModel(
   n: number = 20,
+  type?: "webgl" | "webgpu",
 ): Promise<ColorableMergedView> {
+  type = type ?? "webgl";
   const option = {
     bodyOption: { color: [1, 1, 1, 0.2] as [number, number, number, number] },
     edgeOption: { color: [1, 1, 1, 0.8] as [number, number, number, number] },
@@ -51,12 +53,37 @@ export async function generateModel(
   await Promise.all(promises);
   await view.merge();
 
+  if (type === "webgl") {
+    initMaterial(view, bodyColors, edgeColors);
+  } else if (type === "webgpu") {
+    initNodeMaterial(view, bodyColors, edgeColors);
+  }
+
+  return view;
+}
+
+const initMaterial = (
+  view: ColorableMergedView,
+  bodyColors: TweenableColorMap,
+  edgeColors: TweenableColorMap,
+) => {
   if (view.body) {
     view.body.material = new ColorableMergedBodyMaterial(bodyColors);
   }
   if (view.edge) {
     view.edge.material = new ColorableMergedEdgeMaterial(edgeColors);
   }
+};
 
-  return view;
-}
+const initNodeMaterial = (
+  view: ColorableMergedView,
+  bodyColors: TweenableColorMap,
+  edgeColors: TweenableColorMap,
+) => {
+  if (view.body) {
+    view.body.material = new ColorableMergedBodyNodeMaterial(bodyColors);
+  }
+  if (view.edge) {
+    view.edge.material = new ColorableMergedEdgeNodeMaterial(edgeColors);
+  }
+};

--- a/demoSrc/GenerateScene.ts
+++ b/demoSrc/GenerateScene.ts
@@ -1,4 +1,4 @@
-import { PerspectiveCamera, Scene, WebGLRenderer } from "three";
+import { Color, PerspectiveCamera, Scene, WebGLRenderer } from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 import Stats from "three/examples/jsm/libs/stats.module.js";
 import WebGPURenderer from "three/examples/jsm/renderers/webgpu/WebGPURenderer.js";
@@ -14,7 +14,10 @@ const generateSceneObjects = (type: "webgl" | "webgpu") => {
     type === "webgl"
       ? new WebGLRenderer({ antialias: true })
       : new WebGPURenderer({ antialias: true });
+
   renderer.setSize(w, h);
+  renderer.setClearColor(new Color(0x000000));
+
   document.body.appendChild(renderer.domElement);
   const rendererInfo = document.createElement("div");
   document.body.appendChild(rendererInfo);

--- a/demoSrc/GenerateScene.ts
+++ b/demoSrc/GenerateScene.ts
@@ -1,15 +1,19 @@
 import { PerspectiveCamera, Scene, WebGLRenderer } from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
-import Stats from "three/examples/jsm/libs/stats.module";
+import Stats from "three/examples/jsm/libs/stats.module.js";
+import WebGPURenderer from "three/examples/jsm/renderers/webgpu/WebGPURenderer.js";
 
-export function generateScene() {
+const generateSceneObjects = (type: "webgl" | "webgpu") => {
   const w = 1280;
   const h = 720;
   const scene = new Scene();
   const camera = new PerspectiveCamera(45, w / h, 1, 60000);
   camera.position.set(0, 0, 15);
 
-  const renderer = new WebGLRenderer({ antialias: true });
+  const renderer =
+    type === "webgl"
+      ? new WebGLRenderer({ antialias: true })
+      : new WebGPURenderer({ antialias: true });
   renderer.setSize(w, h);
   document.body.appendChild(renderer.domElement);
   const rendererInfo = document.createElement("div");
@@ -19,14 +23,25 @@ export function generateScene() {
   const stats = new Stats();
   const rendering = () => {
     stats.begin();
-    renderer.render(scene, camera);
+    if (renderer instanceof WebGLRenderer) {
+      renderer.render(scene, camera);
+    } else if (renderer instanceof WebGPURenderer) {
+      renderer.renderAsync(scene, camera);
+    }
     stats.end();
 
     rendererInfo.innerText = JSON.stringify(renderer.info.render);
-    renderer.render(scene, camera);
     requestAnimationFrame(rendering);
   };
   rendering();
 
   return scene;
+};
+
+export function generateScene() {
+  return generateSceneObjects("webgl");
+}
+
+export function generateWebGPUScene() {
+  return generateSceneObjects("webgpu");
 }

--- a/demoSrc/demo_NodeMaterial.ts
+++ b/demoSrc/demo_NodeMaterial.ts
@@ -1,0 +1,13 @@
+import { ColorableMergedView } from "../src/index.js";
+import { generateModel } from "./GenarateModel.js";
+import { generateWebGPUScene } from "./GenerateScene.js";
+import { ColorSwitcher } from "./ColorSwitcher.js";
+
+const onDomContentsLoaded = async () => {
+  const scene = generateWebGPUScene();
+  const model: ColorableMergedView = await generateModel(20, "webgpu");
+  scene.add(model);
+  new ColorSwitcher(model);
+};
+
+window.onload = onDomContentsLoaded;

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "preversion": "git checkout main && git pull && npm ci && npx vitest --run && npm run build",
     "postversion": "git add package.json package-lock.json && git checkout -b version/$(git describe --tags --abbrev=0)",
     "buildTS": "tsc",
-    "start:dev": "npm run server & npm run watch:tsc & npm run watch:workerBundle & npm run watch:demo",
+    "start:dev": "npm run server & npm run watch:tsc & npm run watch:demo",
     "build": "npm run buildTS & npm run typedocs & npm run demo",
     "demo": "npx @masatomakino/gulptask-demo-page --compileTarget ES2021 --compileModule es2020",
     "typedocs": "npx typedoc --out ./docs/api src/index.ts",

--- a/src/ColorableMergedEdge.ts
+++ b/src/ColorableMergedEdge.ts
@@ -1,8 +1,5 @@
 import { LineSegments } from "three";
-import {
-  ColorableMergedEdgeMaterialParam,
-  EdgeGeometryMerger,
-} from "./index.js";
+import { EdgeGeometryMerger } from "./index.js";
 
 export interface ColorableMergedEdgeParam {
   edgeDetail?: number;

--- a/src/ColorableMergedView.ts
+++ b/src/ColorableMergedView.ts
@@ -6,6 +6,10 @@ import {
   ColorableMergedEdgeParam,
 } from "./index.js";
 
+/**
+ * 色変更アニメーションのパラメータ。
+ * 変更後の色と、その色に変化するまでの時間とイージング関数を指定する。
+ */
 export interface ChangeColorParam {
   bodyColor?: [number, number, number, number];
   edgeColor?: [number, number, number, number];
@@ -15,6 +19,13 @@ export interface ChangeColorParam {
   duration?: number;
   now?: number;
 }
+
+/**
+ * 色変更が可能なモデル。
+ *
+ * 半透明なモデルと、エッジの組み合わせで構成される。
+ * それぞれに対して、色変更アニメーションができる。
+ */
 export class ColorableMergedView extends Group {
   static readonly MODEL_INDEX = "MODEL_INDEX";
 
@@ -36,9 +47,11 @@ export class ColorableMergedView extends Group {
   constructor(option: {
     bodyOption?: ColorableMergedBodyParam;
     edgeOption?: ColorableMergedEdgeParam;
+    rendererType?: "webgl" | "webgpu"; //default : webgl
   }) {
     super();
 
+    option.rendererType = option.rendererType ?? "webgl";
     if (option.bodyOption != null) {
       this.body = new ColorableMergedBody(option.bodyOption);
       this.add(this.body);

--- a/src/ColorableMergedView.ts
+++ b/src/ColorableMergedView.ts
@@ -47,11 +47,9 @@ export class ColorableMergedView extends Group {
   constructor(option: {
     bodyOption?: ColorableMergedBodyParam;
     edgeOption?: ColorableMergedEdgeParam;
-    rendererType?: "webgl" | "webgpu"; //default : webgl
   }) {
     super();
 
-    option.rendererType = option.rendererType ?? "webgl";
     if (option.bodyOption != null) {
       this.body = new ColorableMergedBody(option.bodyOption);
       this.add(this.body);

--- a/src/TweenableColorMap.ts
+++ b/src/TweenableColorMap.ts
@@ -116,7 +116,7 @@ export class TweenableColorMap extends EventEmitter {
       if (material instanceof ShaderMaterial) {
         return material.uniforms[this.uniformName].value as Vector4[];
       }
-      return material.uniformColorArray;
+      return material.uniformColors;
     };
     const colorUniform = getUniform(this.material);
 

--- a/src/TweenableColorMap.ts
+++ b/src/TweenableColorMap.ts
@@ -6,6 +6,7 @@ import { Easing } from "@tweenjs/tween.js";
 import { EventEmitter } from "eventemitter3";
 import { ShaderMaterial, Vector4 } from "three";
 import { IColorableMergedNodeMaterial } from "./material/index.js";
+import { UniformNode } from "three/examples/jsm/nodes/Nodes.js";
 
 export class TweenableColorMap extends EventEmitter {
   readonly colors: Map<string, TweenableColor> = new Map();
@@ -115,7 +116,7 @@ export class TweenableColorMap extends EventEmitter {
       if (material instanceof ShaderMaterial) {
         return material.uniforms[this.uniformName].value as Vector4[];
       }
-      return material.uniformColors.value as Vector4[];
+      return material.uniformColorArray;
     };
     const colorUniform = getUniform(this.material);
 
@@ -129,6 +130,12 @@ export class TweenableColorMap extends EventEmitter {
     const index = this.getUniformIndexFromColor(tweenableColor);
     const colorAttribute = tweenableColor.getAttribute();
 
-    colorUniform[index].set(...colorAttribute);
+    if (this.material instanceof ShaderMaterial) {
+      (colorUniform[index] as Vector4).set(...colorAttribute);
+    } else {
+      (colorUniform[index] as UniformNode<Vector4>).value.set(
+        ...colorAttribute,
+      );
+    }
   }
 }

--- a/src/TweenableColorMap.ts
+++ b/src/TweenableColorMap.ts
@@ -5,10 +5,11 @@ import {
 import { Easing } from "@tweenjs/tween.js";
 import { EventEmitter } from "eventemitter3";
 import { ShaderMaterial, Vector4 } from "three";
+import { IColorableMergedNodeMaterial } from "./material/index.js";
 
 export class TweenableColorMap extends EventEmitter {
   readonly colors: Map<string, TweenableColor> = new Map();
-  private material?: ShaderMaterial;
+  private material?: ShaderMaterial | IColorableMergedNodeMaterial;
 
   /**
    * コンストラクタ
@@ -19,7 +20,7 @@ export class TweenableColorMap extends EventEmitter {
     TweenableColorTicker.start();
   }
 
-  setMaterial(material: ShaderMaterial) {
+  setMaterial(material: ShaderMaterial | IColorableMergedNodeMaterial) {
     this.material = material;
   }
 
@@ -107,8 +108,16 @@ export class TweenableColorMap extends EventEmitter {
   private updateUniform(tweenableColor: TweenableColor): void {
     if (this.material == null) return;
 
-    const colorUniform = this.material.uniforms[this.uniformName]
-      .value as Vector4[];
+    const getUniform = (
+      material: ShaderMaterial | IColorableMergedNodeMaterial,
+    ) => {
+      if (material == null) return undefined;
+      if (material instanceof ShaderMaterial) {
+        return material.uniforms[this.uniformName].value as Vector4[];
+      }
+      return material.uniformColors.value as Vector4[];
+    };
+    const colorUniform = getUniform(this.material);
 
     if (colorUniform == null) {
       console.error(

--- a/src/TweenableColorMap.ts
+++ b/src/TweenableColorMap.ts
@@ -6,7 +6,6 @@ import { Easing } from "@tweenjs/tween.js";
 import { EventEmitter } from "eventemitter3";
 import { ShaderMaterial, Vector4 } from "three";
 import { IColorableMergedNodeMaterial } from "./material/index.js";
-import { UniformNode } from "three/examples/jsm/nodes/Nodes.js";
 
 export class TweenableColorMap extends EventEmitter {
   readonly colors: Map<string, TweenableColor> = new Map();
@@ -116,7 +115,7 @@ export class TweenableColorMap extends EventEmitter {
       if (material instanceof ShaderMaterial) {
         return material.uniforms[this.uniformName].value as Vector4[];
       }
-      return material.uniformColors;
+      return material.indexedColors;
     };
     const colorUniform = getUniform(this.material);
 
@@ -129,13 +128,6 @@ export class TweenableColorMap extends EventEmitter {
 
     const index = this.getUniformIndexFromColor(tweenableColor);
     const colorAttribute = tweenableColor.getAttribute();
-
-    if (this.material instanceof ShaderMaterial) {
-      (colorUniform[index] as Vector4).set(...colorAttribute);
-    } else {
-      (colorUniform[index] as UniformNode<Vector4>).value.set(
-        ...colorAttribute,
-      );
-    }
+    colorUniform[index].set(...colorAttribute);
   }
 }

--- a/src/material/ColorableMergedBodyNodeMaterial.ts
+++ b/src/material/ColorableMergedBodyNodeMaterial.ts
@@ -50,10 +50,7 @@ export class ColorableMergedBodyNodeMaterial
     });
 
     const color = this.uniformColors[0];
-    this.colorNode = vec4(color).xyz;
-
-    //TODO : update alphaNode
-    this.opacityNode = vec4(color).w;
+    this.colorNode = vec4(color);
 
     this.transparent = true;
     this.blending = param?.blending ?? NormalBlending;

--- a/src/material/ColorableMergedBodyNodeMaterial.ts
+++ b/src/material/ColorableMergedBodyNodeMaterial.ts
@@ -4,20 +4,26 @@ import {
   ShaderNodeObject,
   UniformNode,
   uniform,
+  attribute,
+  float,
+  vec3,
+  vec4,
+  uniforms,
+  tslFn,
 } from "three/examples/jsm/nodes/Nodes.js";
 import { TweenableColorMap } from "../TweenableColorMap.js";
 import {
   ColorableMergedBodyMaterialParam,
   IColorableMergedNodeMaterial,
 } from "./index.js";
+import { ColorableMergedView } from "../ColorableMergedView.js";
 
 export class ColorableMergedBodyNodeMaterial
   extends MeshBasicNodeMaterial
   implements IColorableMergedNodeMaterial
 {
   readonly isColorableMergedMaterial: boolean = true;
-
-  readonly uniformColors: ShaderNodeObject<UniformNode<Vector4[]>>;
+  readonly uniformColorArray: UniformNode<Vector4>[] = [];
 
   constructor(
     readonly colors: TweenableColorMap,
@@ -29,13 +35,17 @@ export class ColorableMergedBodyNodeMaterial
           このMaterialに紐づけられたTweenableColoMapには1つもTweenableColorが登録されていません。`);
     }
 
-    this.uniformColors = ColorableMergedBodyNodeMaterial.getColorUniform(
+    ColorableMergedBodyNodeMaterial.initColorUniformArray(
       colors.getSize(),
+      this.uniformColorArray,
     );
 
     //TODO : update colorNode
+    const uniform = this.uniformColorArray[0];
+    this.colorNode = vec3(uniform).xyz;
 
     //TODO : update alphaNode
+    this.opacityNode = vec4(uniform).w;
 
     this.transparent = true;
     this.blending = param?.blending ?? NormalBlending;
@@ -45,13 +55,12 @@ export class ColorableMergedBodyNodeMaterial
     colors.updateUniformsAll();
   }
 
-  static getColorUniform(
+  static initColorUniformArray(
     colorLength: number,
-  ): ShaderNodeObject<UniformNode<Vector4[]>> {
-    const colors = new Array(colorLength)
-      .fill(0)
-      .map(() => new Vector4(1, 1, 1, 0.5));
-
-    return uniform(colors);
+    uniformColorArray: UniformNode<Vector4>[] = [],
+  ) {
+    for (let i = 0; i < colorLength; i++) {
+      uniformColorArray.push(uniform(new Vector4(1, 1, 1, 0.5)));
+    }
   }
 }

--- a/src/material/ColorableMergedBodyNodeMaterial.ts
+++ b/src/material/ColorableMergedBodyNodeMaterial.ts
@@ -1,0 +1,49 @@
+import { FrontSide, NormalBlending, Vector4 } from "three";
+import {
+  MeshBasicNodeMaterial,
+  ShaderNodeObject,
+  UniformNode,
+  uniform,
+} from "three/examples/jsm/nodes/Nodes.js";
+import { TweenableColorMap } from "../TweenableColorMap.js";
+import { ColorableMergedBodyMaterialParam } from "./ColorableMergedBodyMaterial.js";
+import { IColorableMergedNodeMaterial } from "./IColorableMergedNodeMaterial.js";
+
+export class ColorableMergedBodyNodeMaterial
+  extends MeshBasicNodeMaterial
+  implements IColorableMergedNodeMaterial
+{
+  readonly isColorableMergedMaterial: boolean = true;
+
+  readonly uniformColors: ShaderNodeObject<UniformNode<Vector4[]>>;
+
+  constructor(
+    readonly colors: TweenableColorMap,
+    param?: ColorableMergedBodyMaterialParam,
+  ) {
+    super();
+    if (colors.getSize() === 0) {
+      throw new Error(`ColorableMergedNodeMaterialには少なくとも1つ以上のTweenableColorが必要です。
+          このMaterialに紐づけられたTweenableColoMapには1つもTweenableColorが登録されていません。`);
+    }
+
+    this.uniformColors = ColorableMergedBodyNodeMaterial.getColorUniform(
+      colors.getSize(),
+    );
+
+    this.transparent = true;
+    this.blending = param?.blending ?? NormalBlending;
+    this.side = param?.side ?? FrontSide;
+
+    colors.setMaterial(this);
+    colors.updateUniformsAll();
+  }
+
+  static getColorUniform(colorLength: number) {
+    const colors = new Array(colorLength)
+      .fill(0)
+      .map(() => new Vector4(1, 1, 1, 0.5));
+
+    return uniform(colors);
+  }
+}

--- a/src/material/ColorableMergedBodyNodeMaterial.ts
+++ b/src/material/ColorableMergedBodyNodeMaterial.ts
@@ -6,8 +6,10 @@ import {
   uniform,
 } from "three/examples/jsm/nodes/Nodes.js";
 import { TweenableColorMap } from "../TweenableColorMap.js";
-import { ColorableMergedBodyMaterialParam } from "./ColorableMergedBodyMaterial.js";
-import { IColorableMergedNodeMaterial } from "./IColorableMergedNodeMaterial.js";
+import {
+  ColorableMergedBodyMaterialParam,
+  IColorableMergedNodeMaterial,
+} from "./index.js";
 
 export class ColorableMergedBodyNodeMaterial
   extends MeshBasicNodeMaterial
@@ -31,6 +33,10 @@ export class ColorableMergedBodyNodeMaterial
       colors.getSize(),
     );
 
+    //TODO : update colorNode
+
+    //TODO : update alphaNode
+
     this.transparent = true;
     this.blending = param?.blending ?? NormalBlending;
     this.side = param?.side ?? FrontSide;
@@ -39,7 +45,9 @@ export class ColorableMergedBodyNodeMaterial
     colors.updateUniformsAll();
   }
 
-  static getColorUniform(colorLength: number) {
+  static getColorUniform(
+    colorLength: number,
+  ): ShaderNodeObject<UniformNode<Vector4[]>> {
     const colors = new Array(colorLength)
       .fill(0)
       .map(() => new Vector4(1, 1, 1, 0.5));

--- a/src/material/ColorableMergedBodyNodeMaterial.ts
+++ b/src/material/ColorableMergedBodyNodeMaterial.ts
@@ -23,7 +23,7 @@ export class ColorableMergedBodyNodeMaterial
   implements IColorableMergedNodeMaterial
 {
   readonly isColorableMergedMaterial: boolean = true;
-  readonly uniformColorArray: UniformNode<Vector4>[] = [];
+  readonly uniformColors: UniformNode<Vector4>[] = [];
 
   constructor(
     readonly colors: TweenableColorMap,
@@ -37,15 +37,23 @@ export class ColorableMergedBodyNodeMaterial
 
     ColorableMergedBodyNodeMaterial.initColorUniformArray(
       colors.getSize(),
-      this.uniformColorArray,
+      this.uniformColors,
     );
 
     //TODO : update colorNode
-    const uniform = this.uniformColorArray[0];
-    this.colorNode = vec3(uniform).xyz;
+    const getColorVector4 = tslFn(([uniforms]: [UniformNode<Vector4>[]]) => {
+      //ここで取得できるのはany型で、index用の値が入っているがキャストできない
+      const index = attribute(ColorableMergedView.MODEL_INDEX);
+      //indexのキャストに失敗したため固定値0を指定している
+      const color = vec4(uniforms[0]);
+      return color;
+    });
+
+    const color = this.uniformColors[0];
+    this.colorNode = vec4(color).xyz;
 
     //TODO : update alphaNode
-    this.opacityNode = vec4(uniform).w;
+    this.opacityNode = vec4(color).w;
 
     this.transparent = true;
     this.blending = param?.blending ?? NormalBlending;

--- a/src/material/ColorableMergedEdgeNodeMaterial.ts
+++ b/src/material/ColorableMergedEdgeNodeMaterial.ts
@@ -1,7 +1,8 @@
 import { Vector4 } from "three";
 import {
   LineBasicNodeMaterial,
-  UniformNode,
+  ShaderNodeObject,
+  UniformsNode,
 } from "three/examples/jsm/nodes/Nodes.js";
 import { TweenableColorMap } from "../TweenableColorMap.js";
 import { ColorableMergedBodyNodeMaterial } from "./ColorableMergedBodyNodeMaterial.js";
@@ -15,7 +16,8 @@ export class ColorableMergedEdgeNodeMaterial
   implements IColorableMergedNodeMaterial
 {
   readonly isColorableMergedMaterial: boolean = true;
-  readonly uniformColors: UniformNode<Vector4>[] = [];
+  readonly indexedColors: Vector4[];
+  readonly uniformsColorArray: ShaderNodeObject<UniformsNode>;
 
   constructor(
     readonly colors: TweenableColorMap,
@@ -23,10 +25,13 @@ export class ColorableMergedEdgeNodeMaterial
   ) {
     super();
 
-    ColorableMergedBodyNodeMaterial.initColorUniformArray(
+    this.indexedColors = ColorableMergedBodyNodeMaterial.initColorUniformArray(
       colors.getSize(),
-      this.uniformColors,
     );
+    this.uniformsColorArray =
+      ColorableMergedBodyNodeMaterial.initUniformsColorArray(
+        this.indexedColors,
+      );
     this.depthWrite = param?.depthWrite ?? true;
     this.transparent = true;
 

--- a/src/material/ColorableMergedEdgeNodeMaterial.ts
+++ b/src/material/ColorableMergedEdgeNodeMaterial.ts
@@ -15,7 +15,7 @@ export class ColorableMergedEdgeNodeMaterial
   implements IColorableMergedNodeMaterial
 {
   readonly isColorableMergedMaterial: boolean = true;
-  readonly uniformColorArray: UniformNode<Vector4>[] = [];
+  readonly uniformColors: UniformNode<Vector4>[] = [];
 
   constructor(
     readonly colors: TweenableColorMap,
@@ -25,7 +25,7 @@ export class ColorableMergedEdgeNodeMaterial
 
     ColorableMergedBodyNodeMaterial.initColorUniformArray(
       colors.getSize(),
-      this.uniformColorArray,
+      this.uniformColors,
     );
     this.depthWrite = param?.depthWrite ?? true;
     this.transparent = true;

--- a/src/material/ColorableMergedEdgeNodeMaterial.ts
+++ b/src/material/ColorableMergedEdgeNodeMaterial.ts
@@ -1,0 +1,40 @@
+import { Vector4 } from "three";
+import {
+  LineBasicNodeMaterial,
+  ShaderNodeObject,
+  UniformNode,
+} from "three/examples/jsm/nodes/Nodes.js";
+import { TweenableColorMap } from "../TweenableColorMap.js";
+import { ColorableMergedBodyNodeMaterial } from "./ColorableMergedBodyNodeMaterial.js";
+import {
+  ColorableMergedEdgeMaterialParam,
+  IColorableMergedNodeMaterial,
+} from "./index.js";
+
+export class ColorableMergedEdgeNodeMaterial
+  extends LineBasicNodeMaterial
+  implements IColorableMergedNodeMaterial
+{
+  readonly isColorableMergedMaterial: boolean = true;
+  readonly uniformColors: ShaderNodeObject<UniformNode<Vector4[]>>;
+
+  constructor(
+    readonly colors: TweenableColorMap,
+    param?: ColorableMergedEdgeMaterialParam,
+  ) {
+    super();
+
+    this.uniformColors = ColorableMergedBodyNodeMaterial.getColorUniform(
+      colors.getSize(),
+    );
+    this.depthWrite = param?.depthWrite ?? true;
+    this.transparent = true;
+
+    //TODO : update colorNode
+
+    //TODO : update alphaNode
+
+    colors.setMaterial(this);
+    colors.updateUniformsAll();
+  }
+}

--- a/src/material/ColorableMergedEdgeNodeMaterial.ts
+++ b/src/material/ColorableMergedEdgeNodeMaterial.ts
@@ -1,7 +1,6 @@
 import { Vector4 } from "three";
 import {
   LineBasicNodeMaterial,
-  ShaderNodeObject,
   UniformNode,
 } from "three/examples/jsm/nodes/Nodes.js";
 import { TweenableColorMap } from "../TweenableColorMap.js";
@@ -16,7 +15,7 @@ export class ColorableMergedEdgeNodeMaterial
   implements IColorableMergedNodeMaterial
 {
   readonly isColorableMergedMaterial: boolean = true;
-  readonly uniformColors: ShaderNodeObject<UniformNode<Vector4[]>>;
+  readonly uniformColorArray: UniformNode<Vector4>[] = [];
 
   constructor(
     readonly colors: TweenableColorMap,
@@ -24,8 +23,9 @@ export class ColorableMergedEdgeNodeMaterial
   ) {
     super();
 
-    this.uniformColors = ColorableMergedBodyNodeMaterial.getColorUniform(
+    ColorableMergedBodyNodeMaterial.initColorUniformArray(
       colors.getSize(),
+      this.uniformColorArray,
     );
     this.depthWrite = param?.depthWrite ?? true;
     this.transparent = true;

--- a/src/material/IColorableMergedNodeMaterial.ts
+++ b/src/material/IColorableMergedNodeMaterial.ts
@@ -1,11 +1,8 @@
 import { Vector4 } from "three";
-import {
-  ShaderNodeObject,
-  UniformNode,
-} from "three/examples/jsm/nodes/Nodes.js";
+import { UniformNode } from "three/examples/jsm/nodes/Nodes.js";
 import { IColorableMergedMaterial } from "./IColorableMergedMaterial.js";
 
 export interface IColorableMergedNodeMaterial extends IColorableMergedMaterial {
-  readonly uniformColors: ShaderNodeObject<UniformNode<Vector4[]>>;
+  readonly uniformColorArray: UniformNode<Vector4>[];
   name: string;
 }

--- a/src/material/IColorableMergedNodeMaterial.ts
+++ b/src/material/IColorableMergedNodeMaterial.ts
@@ -1,8 +1,12 @@
 import { Vector4 } from "three";
-import { UniformNode } from "three/examples/jsm/nodes/Nodes.js";
+import {
+  ShaderNodeObject,
+  UniformsNode,
+} from "three/examples/jsm/nodes/Nodes.js";
 import { IColorableMergedMaterial } from "./IColorableMergedMaterial.js";
 
 export interface IColorableMergedNodeMaterial extends IColorableMergedMaterial {
-  readonly uniformColors: UniformNode<Vector4>[];
+  readonly indexedColors: Vector4[];
+  readonly uniformsColorArray: ShaderNodeObject<UniformsNode>;
   name: string;
 }

--- a/src/material/IColorableMergedNodeMaterial.ts
+++ b/src/material/IColorableMergedNodeMaterial.ts
@@ -1,0 +1,11 @@
+import { Vector4 } from "three";
+import {
+  ShaderNodeObject,
+  UniformNode,
+} from "three/examples/jsm/nodes/Nodes.js";
+import { IColorableMergedMaterial } from "./IColorableMergedMaterial.js";
+
+export interface IColorableMergedNodeMaterial extends IColorableMergedMaterial {
+  readonly uniformColors: ShaderNodeObject<UniformNode<Vector4[]>>;
+  name: string;
+}

--- a/src/material/IColorableMergedNodeMaterial.ts
+++ b/src/material/IColorableMergedNodeMaterial.ts
@@ -3,6 +3,6 @@ import { UniformNode } from "three/examples/jsm/nodes/Nodes.js";
 import { IColorableMergedMaterial } from "./IColorableMergedMaterial.js";
 
 export interface IColorableMergedNodeMaterial extends IColorableMergedMaterial {
-  readonly uniformColorArray: UniformNode<Vector4>[];
+  readonly uniformColors: UniformNode<Vector4>[];
   name: string;
 }

--- a/src/material/index.ts
+++ b/src/material/index.ts
@@ -9,3 +9,5 @@ export {
   ColorableMergedEdgeMaterial,
   ColorableMergedEdgeMaterialParam,
 } from "./ColorableMergedEdgeMaterial.js";
+export * from "./ColorableMergedBodyNodeMaterial.js";
+export * from "./ColorableMergedEdgeNodeMaterial.js";

--- a/src/material/index.ts
+++ b/src/material/index.ts
@@ -1,4 +1,5 @@
 export * from "./IColorableMergedMaterial.js";
+export * from "./IColorableMergedNodeMaterial.js";
 export * from "./ColorableMergedMaterial.js";
 export {
   ColorableMergedBodyMaterial,


### PR DESCRIPTION
#111

WebGPUおよびNodeMaterial, TSLに対応したカラーマテリアル。

opacityの効きがWebGLRendererとWebGPURendererで異なるようで、レンダリング結果はWebGPURendererの方が明るい。プロダクション環境ではOpacityの調整が必要。