### PR TITLE
fix : remove unused uniform

### DIFF
--- a/src/material/ColorableMergedBodyNodeMaterial.ts
+++ b/src/material/ColorableMergedBodyNodeMaterial.ts
@@ -7,6 +7,8 @@ import {
   attribute,
   uniform,
   uniforms,
+  materialColor,
+  materialOpacity,
 } from "three/examples/jsm/nodes/Nodes.js";
 import { ColorableMergedView } from "../ColorableMergedView.js";
 import { TweenableColorMap } from "../TweenableColorMap.js";
@@ -22,8 +24,6 @@ export class ColorableMergedBodyNodeMaterial
   readonly isColorableMergedMaterial: boolean = true;
   readonly indexedColors: Vector4[] = [];
   readonly uniformsColorArray: ShaderNodeObject<UniformsNode>;
-  readonly materialColorUniform: ShaderNodeObject<UniformNode<Color>>;
-  readonly materialOpacityUniform: ShaderNodeObject<UniformNode<number>>;
 
   constructor(
     readonly colors: TweenableColorMap,
@@ -43,14 +43,11 @@ export class ColorableMergedBodyNodeMaterial
         this.indexedColors,
       );
 
-    this.materialColorUniform = uniform(this.color);
-    this.materialOpacityUniform = uniform(this.opacity);
-
     const colorElement = this.uniformsColorArray.element(
       attribute(ColorableMergedView.MODEL_INDEX) as unknown as number,
     );
-    this.colorNode = this.materialColorUniform.mul(colorElement.xyz);
-    this.opacityNode = this.materialOpacityUniform.mul(colorElement.w);
+    this.colorNode = materialColor.mul(colorElement.xyz);
+    this.opacityNode = materialOpacity.mul(colorElement.w);
 
     this.transparent = true;
     this.blending = param?.blending ?? NormalBlending;

--- a/src/material/ColorableMergedEdgeNodeMaterial.ts
+++ b/src/material/ColorableMergedEdgeNodeMaterial.ts
@@ -1,11 +1,11 @@
-import { Color, Vector4 } from "three";
+import { Vector4 } from "three";
 import {
   LineBasicNodeMaterial,
   ShaderNodeObject,
-  UniformNode,
   UniformsNode,
   attribute,
-  uniform,
+  materialColor,
+  materialOpacity,
 } from "three/examples/jsm/nodes/Nodes.js";
 import { TweenableColorMap } from "../TweenableColorMap.js";
 import { ColorableMergedBodyNodeMaterial } from "./ColorableMergedBodyNodeMaterial.js";
@@ -22,8 +22,6 @@ export class ColorableMergedEdgeNodeMaterial
   readonly isColorableMergedMaterial: boolean = true;
   readonly indexedColors: Vector4[];
   readonly uniformsColorArray: ShaderNodeObject<UniformsNode>;
-  readonly materialColorUniform: ShaderNodeObject<UniformNode<Color>>;
-  readonly materialOpacityUniform: ShaderNodeObject<UniformNode<number>>;
 
   constructor(
     readonly colors: TweenableColorMap,
@@ -43,16 +41,14 @@ export class ColorableMergedEdgeNodeMaterial
         this.indexedColors,
       );
 
-    this.materialColorUniform = uniform(this.color);
-    this.materialOpacityUniform = uniform(this.opacity);
     this.depthWrite = param?.depthWrite ?? true;
     this.transparent = true;
 
     const colorElement = this.uniformsColorArray.element(
       attribute(ColorableMergedView.MODEL_INDEX) as unknown as number,
     );
-    this.colorNode = this.materialColorUniform.mul(colorElement.xyz);
-    this.opacityNode = this.materialOpacityUniform.mul(colorElement.w);
+    this.colorNode = materialColor.mul(colorElement.xyz);
+    this.opacityNode = materialOpacity.mul(colorElement.w);
 
     colors.setMaterial(this);
     colors.updateUniformsAll();


### PR DESCRIPTION
マテリアルのプロパティへは、アクセサ"materialXX"でnodeとしてアクセス可能