### PR TITLE
feat: add .claude/settings.local.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ out
 .idea
 docs/
 dist/
+
+# Claude Code settings
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
Add `.claude/settings.local.json` to `.gitignore` to exclude personal Claude Code settings from version control.

## Rationale
- Personal Claude Code settings contain user-specific configurations and permissions
- These settings should not be shared across team members
- Following standard practice of ignoring local configuration files

## Test plan
- [x] Verified `.gitignore` entry prevents tracking of local settings
- [x] All existing tests continue to pass
- [x] No impact on build or functionality

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the ignore list to exclude a local settings file used by Claude Code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->