### PR TITLE
docs(README): add npm version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # colorable-merged-model
 
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
+[![npm version](https://img.shields.io/npm/v/@masatomakino/colorable-merged-model.svg?style=flat)](https://www.npmjs.com/package/@masatomakino/colorable-merged-model)
 [![GitHub](https://img.shields.io/badge/GitHub-Repository-blue?logo=github&style=flat)](https://github.com/MasatoMakino/colorable-merged-model)
 
 A TypeScript library for Three.js that provides colorable merged geometries with both mesh bodies and edge lines. This library allows dynamic color changes on individual geometries after they have been merged, which is essential for performance optimization in Three.js applications.


### PR DESCRIPTION
## Summary

- Add shields.io npm version badge to README.md
- Badge displays current package version from npm registry
- Clicking the badge navigates to npm package page

## Scope

**Changes:**
- Add npm version badge between license and GitHub badges

**Unchanged:**
- All other README content remains identical

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated README to display npm package version information through an added badge, enabling users to quickly reference the current version directly from the project documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->